### PR TITLE
UPDATE LD_LIBRARY_PATH(s) for 64bit

### DIFF
--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -972,7 +972,7 @@ static void execchild(void *user_data) {
 		addnewvar("ANDROID_ROOT", "/system");
 		addnewvar("BOOTCLASSPATH", "/system/framework/core.jar:/system/framework/ext.jar:/system/framework/framework.jar:/system/framework/android.policy.jar:/system/framework/services.jar");
 		addnewvar("EXTERNAL_STORAGE", "/sdcard");
-		addnewvar("LD_LIBRARY_PATH", "/vendor/lib:/system/lib:/system/lib64");
+		addnewvar("LD_LIBRARY_PATH", "/vendor/lib:/vendor/lib64:/system/lib:/system/lib64");
 	} else
 	addnewvar("PATH", DEFAULT_PATH);
 	if (chansess->term != NULL) {

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -972,7 +972,7 @@ static void execchild(void *user_data) {
 		addnewvar("ANDROID_ROOT", "/system");
 		addnewvar("BOOTCLASSPATH", "/system/framework/core.jar:/system/framework/ext.jar:/system/framework/framework.jar:/system/framework/android.policy.jar:/system/framework/services.jar");
 		addnewvar("EXTERNAL_STORAGE", "/sdcard");
-		addnewvar("LD_LIBRARY_PATH", "/vendor/lib:/system/lib");
+		addnewvar("LD_LIBRARY_PATH", "/vendor/lib:/system/lib:/system/lib64");
 	} else
 	addnewvar("PATH", DEFAULT_PATH);
 	if (chansess->term != NULL) {


### PR DESCRIPTION
Update to LD_LIBRARY_PATH in svr-chansession.c to include "/system/lib64". This edit will allow dropbear/DroidSSHD to obtain the shell and run terminal commands on 64bit devices even if the binary is compiled as 32bit.
